### PR TITLE
fix: Change user to default root. Use npm instead of yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM circleci/android:api-29-node
 
-RUN yarn global add firebase-tools
+USER root
+
+RUN npm -g install firebase-tools
 


### PR DESCRIPTION
moving to npm as it breaks build if installation fails.